### PR TITLE
removed drive from uart rx/tx pins

### DIFF
--- a/webview-js/constraints-editor.js
+++ b/webview-js/constraints-editor.js
@@ -32,8 +32,8 @@ const TEMPLATES = {
             {name: 'flashCs', location: '60', standard: 'LVCMOS33', pullMode: 'Pull Up', drive: '8ma'}
         ],
         'UART': [
-            {name: 'uartTx', location: '17', standard: 'LVCMOS33', pullMode: 'Pull Up', drive: '8ma'},
-            {name: 'uartRx', location: '18', standard: 'LVCMOS33', pullMode: 'Pull Up', drive: '8ma'}
+            {name: 'uartTx', location: '17', standard: 'LVCMOS33', pullMode: 'Pull Up'},
+            {name: 'uartRx', location: '18', standard: 'LVCMOS33', pullMode: 'Pull Up'}
         ],
         'HDMI': [
             {name: 'hdmiTmdsData[0]', location: '71,70', drive: '8ma'},


### PR DESCRIPTION
so I was following through [your tutorial](https://learn.lushaylabs.com/tang-nano-9k-debugging/), and came across a little bug in the Visual constraints editor. when I generate constraints for the UART pins from template, they get assigned 8mA drive by default:

```IO_LOC  "uart_tx" 17;
IO_PORT "uart_tx" DRIVE=8 IO_TYPE=LVCMOS33 PULL_MODE=UP;
```

this causes problems in the bitstream generation phase, when executing
```
gowin_pack -d ${FAMILY} -o uart.fs uart_pnr.json
```

I get the error:
```
Traceback (most recent call last):
  File "~/Documents/local/oss-cad-suite/lib/python3.8/site-packages/Apycula-0.5.2.dev3+g16a91ef-py3.8.egg/apycula/gowin_pack.py", line 480, in place
KeyError: 'DRIVE'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "~/Documents/local/oss-cad-suite/libexec/gowin_pack", line 33, in <module>
    sys.exit(load_entry_point('Apycula==0.5.2.dev3+g16a91ef', 'console_scripts', 'gowin_pack')())
  File "~/Documents/local/oss-cad-suite/lib/python3.8/site-packages/Apycula-0.5.2.dev3+g16a91ef-py3.8.egg/apycula/gowin_pack.py", line 644, in main
  File "~/Documents/local/oss-cad-suite/lib/python3.8/site-packages/Apycula-0.5.2.dev3+g16a91ef-py3.8.egg/apycula/gowin_pack.py", line 483, in place
Exception: Incorrect attribute DRIVE=8 (iostd:"LVCMOS33", mode:IBUF)
```

the solution is to manually set the "Drive power" to "Unset" in the visual editor, so I think it would be best if it's "unset" by default when creating the uart constraint from template. I made the changes, but I'm not that familiar with typescript nor the codebase, so they could be wrong 😅
