### PR TITLE
Add improvements to the Module Debugger

### DIFF
--- a/src/panels/module-debugger.ts
+++ b/src/panels/module-debugger.ts
@@ -91,7 +91,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
             this._view?.webview.postMessage({
                 command: 'updatedCurrentModules',
                 data: []
-            })
+            });
             return;
         }
         const ossCadPath = await ModuleDebuggerWebviewContentProvider.ossCadSuitePath?.();
@@ -99,7 +99,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
             this._view?.webview.postMessage({
                 command: 'updatedCurrentModules',
                 data: []
-            })
+            });
             return;
         }
         const selectedProject = ModuleDebuggerWebviewContentProvider.selectedProject?.();
@@ -110,7 +110,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
                 data: [],
                 error: 'Please Select a Project',
                 extra: 'This can be done by clicking the button in the bottom toolbar labeled "<Auto-Detect Project>"'
-            })
+            });
             return;
         }
         const projectToUse = selectedProject || {name: 'default', path: numLushayFiles[0].fsPath};
@@ -121,7 +121,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
                 data: [],
                 error: numLushayFiles.length > 1 ? 'Please Select a Project' : 'No Project Found',
                 extra: numLushayFiles.length > 1 ? 'This can be done by clicking the button in the bottom toolbar labeled "<Auto-Detect Project>"' : undefined
-            })
+            });
             return;
         }
         const overrides = await ModuleDebuggerWebviewContentProvider.getOverridePaths?.() || {};
@@ -129,6 +129,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
         const ossRootPath = path.resolve(ossCadPath, '..');
         const res = spawnSync(yosysPath,  ['-p', `read_verilog "${ModuleDebuggerWebviewContentProvider.currentFile.fsPath}"; proc; write_json -compat-int ___module_export.json`], {
             env: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 PATH: [
                     path.join(ossRootPath, 'bin'),
                     path.join(ossRootPath, 'lib'),
@@ -145,7 +146,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
                 data: [],
                 error: 'Error compiling module',
                 extra: res.stderr.toString()
-            })
+            });
             return;
         }
 
@@ -184,7 +185,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
             command: 'updatedCurrentModules',
             data: modulesInFile,
             debugFile: debugFile
-        })
+        });
     }
 
 
@@ -211,7 +212,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
             }
         });
 
-        const outputs = module.ports.filter(p => p.direction === 'output')
+        const outputs = module.ports.filter(p => p.direction === 'output');
 
         newFile.push(`${moduleName} ${moduleName}_inst(`);
         newFile.push(...(module.ports.map(port => `    .${port.name}(${port.name})`).join(',\n').split('\n')));
@@ -225,11 +226,11 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
                     continue;
                 }
                 newFile.push(`    ${key} = ${value.value[i] ?? 0};`);
-                newFile.push(`    $display("${key} = %b", ${key});`)
+                newFile.push(`    $display("${key} = %b", ${key});`);
             }
             newFile.push(`    #0`);
             for (const output of outputs) {
-                newFile.push(`    $display("${output.name} = %b", ${output.name});`)
+                newFile.push(`    $display("${output.name} = %b", ${output.name});`);
             }
             for (const dbg of module.debug) {
                 newFile.push(`    $display("${dbg.name} = %b", ${moduleName}_inst.${dbg.name});`);
@@ -264,6 +265,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
         const res = spawnSync(iverilogPath,  ['-o', `${moduleName}_test.vvp`, '-s', `${moduleName}_test`, `${moduleName}_test.v`, ...(projectFile.includedFilePaths), gowinCellsPath, ...(fs.existsSync(gowinXtraCellsPath) ? [gowinXtraCellsPath] : [])], {
             cwd: testFile,
             env: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 PATH: [
                     path.join(ossRootPath, 'bin'),
                     path.join(ossRootPath, 'lib'),
@@ -286,6 +288,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
         const vvp = spawnSync(vvpPath, [`${moduleName}_test.vvp`], {
             cwd: testFile,
             env: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 PATH: [
                     path.join(ossRootPath, 'bin'),
                     path.join(ossRootPath, 'lib'),
@@ -338,7 +341,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
         return vscode.window.registerWebviewViewProvider(
             ModuleDebuggerWebviewContentProvider.viewType,
             this._instance
-        )
+        );
     }
     public resolveWebviewView(
         webviewView: vscode.WebviewView,

--- a/src/panels/module-debugger.ts
+++ b/src/panels/module-debugger.ts
@@ -6,6 +6,28 @@ import { Uri } from 'vscode';
 import * as fs from 'fs';
 import * as os from 'os';
 
+type ModuleDebuggerInput = {
+    name: string;
+    size: number;
+    value: Record<string, string>;
+    isSubValue?: boolean | undefined;
+};
+
+type ModuleDebuggerCase = {
+    [key: string]: string;
+};
+
+const MODULE_DEBUGGER_RESULT_VERSION = 1;
+type ModuleDebuggerResult = {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __meta__: {
+        version: typeof MODULE_DEBUGGER_RESULT_VERSION
+    }
+} & Record<string, {
+    inputs: Record<string, ModuleDebuggerInput>
+    cases: ModuleDebuggerCase[]
+}>;
+
 export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'lushay-code-module-debugger-content';
     private _view?: vscode.WebviewView;
@@ -27,6 +49,39 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
         if (this._instance) {
             this._instance.updateCurrentFile(fileChanged);
         }
+    }
+
+    private upgradeResultFile(file: ModuleDebuggerResult) {
+        if (file.__meta__?.version === MODULE_DEBUGGER_RESULT_VERSION) {
+            return false;
+        }
+
+        for (const key in file) {
+            if (key === '__meta__') {
+                continue;
+            }
+            const module = file[key];
+            for (const inputName in module.inputs) {
+                const input = module.inputs[inputName];
+                for (let i = 0; i <= 100; i++) {
+                    let value: string | number | undefined = input.value[i] as any;
+                    if (value === undefined) {
+                        continue;
+                    }
+                    if (typeof value === 'number') {
+                        value = value.toString(2).padStart(input.size, '0');
+                    }
+                    else if (typeof value !== 'string') {
+                        value = '0'.repeat(input.size);
+                    }
+                    input.value[i] = value.padStart(input.size, '0').substring(0, input.size);
+                }
+            }
+        }
+
+        file.__meta__ = { version: MODULE_DEBUGGER_RESULT_VERSION };
+
+        return true;
     }
 
     public async updateCurrentFile(changedFile: boolean) {
@@ -93,7 +148,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
         }
         const resLines = res.stdout.toString().replace(/\r\n/g, '\n').split('\n');
         const modulesInFile: Array<{
-            name: string, 
+            name: string,
             ports: Array<{name: string, direction: string, size: number}>
         }> = [];
         let currentModule: {name: string, ports: Array<{name: string, direction: string, size: number}>} | undefined;
@@ -121,9 +176,12 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
         const pathToFile = ModuleDebuggerWebviewContentProvider.currentFile.fsPath;
         const pathWithoutExtension = pathToFile.substring(0, pathToFile.length - 2);
         const dModulePath = pathWithoutExtension + '.dbgmodule';
-        let debugFile = {};
+        let debugFile = {} as ModuleDebuggerResult;
         if (fs.existsSync(dModulePath)) {
-            debugFile = JSON.parse(fs.readFileSync(dModulePath).toString())
+            debugFile = JSON.parse(fs.readFileSync(dModulePath).toString());
+            if (this.upgradeResultFile(debugFile)) {
+                fs.writeFileSync(dModulePath, JSON.stringify(debugFile, null, 4));
+            }
         }
 
         this._view?.webview.postMessage({
@@ -134,7 +192,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
     }
 
 
-    private async createAndRunTestForModule(inputs: Record<string, {name: string, size: number, value: Record<string, number>, isSubValue?: boolean}>, moduleName: string) {
+    private async createAndRunTestForModule(inputs: Record<string, ModuleDebuggerInput>, moduleName: string) {
         const module = this.modulesInFile.find(m => m.name === moduleName);
         if (!module) {
             return;
@@ -254,18 +312,18 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
         return cases;
     }
 
-    async saveResults(inputs: Record<string, { name: string; size: number; value: Record<string, number>; isSubValue?: boolean | undefined; }>, cases: { [key: string]: string; }[], moduleName: string) {
+    async saveResults(inputs: Record<string, ModuleDebuggerInput>, cases: ModuleDebuggerCase[], moduleName: string) {
         const currentFile = ModuleDebuggerWebviewContentProvider.currentFile;
         if (!currentFile) {
             return;
         }
         const pathWithoutExtension = currentFile.fsPath.split('.').slice(0, -1).join('.');
         const dModulePath = `${pathWithoutExtension}.dbgmodule`;
-        let fileContent: Record<string, {inputs: typeof inputs, cases: typeof cases}> = {};
+        let fileContent = {} as ModuleDebuggerResult;
         if (fs.existsSync(dModulePath)) {
             fileContent = JSON.parse(fs.readFileSync(dModulePath).toString());
         }
-
+        this.upgradeResultFile(fileContent);
         fileContent[moduleName] = {
             inputs,
             cases
@@ -302,7 +360,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
         this._view.show?.(true);
         this.updateCurrentFile(true);
     }
-    
+
     private async onMessage(message: any) {
         const { command, data } = message;
         switch (command) {
@@ -325,7 +383,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
         const toolkitUri = webview.asWebviewUri(Uri.joinPath(this._extensionUri, 'node_modules', '@vscode', 'webview-ui-toolkit', 'dist', 'toolkit.js'));
         const mainUri = webview.asWebviewUri(Uri.joinPath(this._extensionUri, 'webview-js', 'module-debugger.js'));
         const codiconsUri = webview.asWebviewUri(Uri.joinPath(this._extensionUri, 'node_modules', '@vscode', 'codicons', 'dist', 'codicon.css'));
-    
+
         return `<!DOCTYPE html>
         <html lang="en">
         <head>
@@ -372,6 +430,13 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
                 .port-line-inactive {
                     border-bottom: 1px solid #0291ff;
                 }
+                .port-line-unknown {
+                    color: #ff0000;
+                    text-align: center;
+                    background: #ff000040;
+                    border-bottom: 1px solid #ff0000;
+                    border-top: 1px solid #ff0000;
+                }
                 .port-agg-handle {
                     position: absolute;
                     top: 0px;
@@ -403,6 +468,12 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
                 }
                 .port-agg-cell:hover {
                     background: #48b0ff;
+                }
+                .port-agg-cell-unknown {
+                    background: #aa0000;
+                }
+                .port-agg-cell-unknown:hover {
+                    background: #ff3333;
                 }
                 .port-input-container {
                     display: flex;
@@ -482,7 +553,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
                     border-top: 1px solid rgba(255, 255, 255, 0.1);
                     font-size: 11px;
                     height: 30px;
-                    
+
                 }
                 .port-cell.port-index {
                     height: 30px;
@@ -548,7 +619,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
         <body>
             <div id="container">
                 <h3>
-                Module Debugger 
+                Module Debugger
                 <vscode-dropdown id="module-select" position="below"></vscode-dropdown>
                 <vscode-button id="clear-button" title="Clear" icon="clear-all">Clear All</vscode-button>
                 </h3>

--- a/webview-js/module-debugger.js
+++ b/webview-js/module-debugger.js
@@ -492,7 +492,10 @@ function makeIntoLineCell(newCell, portName, i, parentPortName, isOutput) {
 
 function updateInputArea(inputs) {
     const newInputs = selectedModule.ports.filter(port => port.direction === 'input');
-    const newOutputs = selectedModule.ports.filter(port => port.direction === 'output');
+    const newOutputs = [
+        ...selectedModule.ports.filter(port => port.direction === 'output'),
+        ...selectedModule.debug
+    ];
     const newInputMap = generateNewInputsMap(newInputs, currentInputs);
     const newOutputMap = generateNewInputsMap(newOutputs, currentOutputs);
     

--- a/webview-js/module-debugger.js
+++ b/webview-js/module-debugger.js
@@ -555,7 +555,7 @@ function updateInputArea(inputs) {
     outerElement.appendChild(inputColumnContainer);
     inputColumnContainer.addEventListener('mousemove', e => {
         if (currentDragMode !== 'agg-left' && currentDragMode !== 'agg-right') { return; }
-        const mousePositionOffset = e.clientX - inputColumnContainer.getBoundingClientRect().left;
+        const mousePositionOffset = e.clientX - inputColumnContainer.getBoundingClientRect().left + inputColumnContainer.scrollLeft;
         const index = Math.floor(mousePositionOffset / 30);
         let changedSomething = false;
         if (currentDragMode === 'agg-left') {


### PR DESCRIPTION
- [Fix: dragging ignores scroll position](https://github.com/lushaylabs/lushay-code/commit/930e91d973c704335da7c0784d4583bb8990b284)
When the module debugger is scrolled to the right and an aggregated input is resized, the selected value jumps to the left because it does not account for the scroll offset.

- [Add support for recognizing X and Z values](https://github.com/lushaylabs/lushay-code/commit/fbdfb4e3f81c1fd9b64329cc733f0229418d3171)
Currently the module debugger assumes that all signals are 0 or 1. Verilog also works with X and Z which led to weird behavior in the debugger when outputs/wires where not driven and registers where not initialized.
For this the value types where changed from numbers to strings and a simple upgrade method was added to convert older `.dbgmodule` files.

- [Add support for displaying registers and wires](https://github.com/lushaylabs/lushay-code/commit/63e7a5bdf2de370e169567c737df83b1d71b434f)
The module debugger currently lackes the ability to debug wires and registers. This PR allows registers and wires to be marked as debug and they will be shown below the outputs.
Example:
```verilog
module dff(input clk, input d, output o);
    (* lc_debug *)
    reg r = 0;
    always @(posedge clk) r <= d;
    assign o = r;
endmodule
```