### PR TITLE
Fix formatting bug that breaks simulation

### DIFF
--- a/src/panels/module-debugger.ts
+++ b/src/panels/module-debugger.ts
@@ -54,10 +54,12 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
     }
 
     private resultNeedsUpgrade(file: ModuleDebuggerResult) {
-        return file.__meta__?.version === MODULE_DEBUGGER_RESULT_VERSION;
+        return file.__meta__?.version !== MODULE_DEBUGGER_RESULT_VERSION;
     }
 
     private upgradeResult(file: ModuleDebuggerResult) {
+        file.__meta__ = { version: MODULE_DEBUGGER_RESULT_VERSION };
+
         for (const key in file) {
             if (key === '__meta__') {
                 continue;
@@ -80,8 +82,6 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
                 }
             }
         }
-
-        file.__meta__ = { version: MODULE_DEBUGGER_RESULT_VERSION };
     }
 
     public async updateCurrentFile(changedFile: boolean) {

--- a/src/panels/module-debugger.ts
+++ b/src/panels/module-debugger.ts
@@ -225,7 +225,7 @@ export class ModuleDebuggerWebviewContentProvider implements vscode.WebviewViewP
                 if (value.isSubValue) {
                     continue;
                 }
-                newFile.push(`    ${key} = ${value.value[i] ?? 0};`);
+                newFile.push(`    ${key} = 'b${value.value[i] ?? "0".repeat(value.size)};`);
                 newFile.push(`    $display("${key} = %b", ${key});`);
             }
             newFile.push(`    #0`);


### PR DESCRIPTION
When switching the inputs from number to string in #8, I forgot to properly format the inputs for the generated testbench which broke the simulation.

I also added code to backup the `.dbgmodule` of version 0.0.19 in case people want to revert back to that version.